### PR TITLE
fix sqlx prepared statement errors; report type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
 name = "derrick-migrate"
 version = "1.0.0-rc1"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "derrick-core",
  "futures-core",

--- a/derrick-core/src/migrations/history.rs
+++ b/derrick-core/src/migrations/history.rs
@@ -82,7 +82,7 @@ pub struct HistoryRow {
     /// when it was applied.
     pub content: String,
     /// How long the migration took to run.
-    pub duration_sec: i64,
+    pub duration_ms: i64,
     /// When the applied migration was inserted.
     pub applied_at: DateTime<Utc>,
 }
@@ -93,7 +93,7 @@ impl From<HistoryRow> for AppliedMigration {
             version: v.version,
             description: v.description,
             content: v.content,
-            duration_sec: v.duration_sec,
+            duration_ms: v.duration_ms,
         }
     }
 }

--- a/derrick-core/src/migrations/migration.rs
+++ b/derrick-core/src/migrations/migration.rs
@@ -29,9 +29,9 @@ impl Migration {
         }
     }
 
-    pub fn new_applied(&self, duration_sec: i64) -> AppliedMigration {
+    pub fn new_applied(&self, duration_ms: i64) -> AppliedMigration {
         AppliedMigration {
-            duration_sec,
+            duration_ms,
             description: self.description.to_string(),
             content: STANDARD.encode(self.content.as_ref()),
             version: self.version,
@@ -50,7 +50,7 @@ pub struct AppliedMigration {
     /// when it was applied.
     pub content: String,
     /// Apply duration.
-    pub duration_sec: i64,
+    pub duration_ms: i64,
 }
 
 impl AppliedMigration {

--- a/derrick-migrate/Cargo.toml
+++ b/derrick-migrate/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 authors.workspace = true
 
 [dependencies]
+base64 = "0.22"
 chrono = { version = "0.4", default-features = false }
 derrick-core.workspace = true
 futures-core = "0.3"

--- a/derrick-migrate/src/lib.rs
+++ b/derrick-migrate/src/lib.rs
@@ -1,7 +1,9 @@
 mod backends;
 pub mod migrate;
+mod report;
 mod runner;
 
+pub use report::{DisplayMigration, MigrationReport};
 pub use runner::Runner;
 
 pub use backends::sqlx::postgres as sqlx_postgres;

--- a/derrick-migrate/src/migrate/pg.rs
+++ b/derrick-migrate/src/migrate/pg.rs
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS {}(
   version bigint PRIMARY KEY,
   description text NOT NULL,
   content text NOT NULL,
-  duration_sec bigint NOT NULL,
+  duration_ms double precision NOT NULL,
   applied_at timestamptz NOT NULL DEFAULT now()
 );
 "#,
@@ -39,7 +39,7 @@ SELECT
   version,
   description,
   content,
-  duration_sec,
+  duration_ms,
   applied_at
 FROM
   {}

--- a/derrick-migrate/src/report.rs
+++ b/derrick-migrate/src/report.rs
@@ -1,0 +1,172 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use derrick_core::types::{AppliedMigration, Migration};
+use log::{log, Level};
+
+#[derive(Debug, Clone)]
+pub struct MigrationReport {
+    report: Vec<DisplayMigration>,
+}
+
+impl MigrationReport {
+    pub fn new(report: Vec<DisplayMigration>) -> Self {
+        Self { report }
+    }
+
+    pub fn display_report(&self) {
+        for m in self.report.iter() {
+            m.display_migration(Level::Info)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DisplayMigration {
+    version: i64,
+    state: MigrationState,
+    description: String,
+    sql: String,
+    transactional: Transactional,
+    duration_ms: RunDuration,
+    error_reason: MigrationErrors,
+}
+
+impl DisplayMigration {
+    pub fn display_migration(&self, level: Level) {
+        log!(level, "{:#?}", self)
+    }
+
+    pub fn from_unapplied(value: &Migration) -> Self {
+        Self {
+            version: value.version,
+            state: MigrationState::Unapplied,
+            description: value.description.to_string(),
+            sql: Self::preview_sql(&value.sql),
+            transactional: Transactional::from_boolean(value.no_tx),
+            duration_ms: RunDuration::Unapplied,
+            error_reason: MigrationErrors::None,
+        }
+    }
+
+    pub fn from_failed(value: &Migration, reason: String) -> Self {
+        Self {
+            version: value.version,
+            state: MigrationState::FailedUnapplied,
+            description: value.description.to_string(),
+            sql: Self::preview_sql(&value.sql),
+            transactional: Transactional::from_boolean(value.no_tx),
+            duration_ms: RunDuration::Unapplied,
+            error_reason: MigrationErrors::Reason(reason),
+        }
+    }
+
+    pub fn from_existing(value: &AppliedMigration) -> Self {
+        Self::from_applied(value, MigrationState::Existing)
+    }
+
+    pub fn from_new_applied(value: &AppliedMigration) -> Self {
+        Self::from_applied(value, MigrationState::NewApplied)
+    }
+
+    fn from_applied(value: &AppliedMigration, state: MigrationState) -> Self {
+        let sql = match STANDARD.decode(&value.content.as_bytes()) {
+            Ok(b) => {
+                if let Ok(decoded) = std::str::from_utf8(&b) {
+                    decoded.to_string()
+                } else {
+                    format!("error base64 decoding...{}", value.content)
+                }
+            }
+            _ => value.content.to_string(),
+        };
+
+        Self {
+            state,
+            version: value.version,
+            description: value.description.to_string(),
+            sql: Self::preview_sql(&sql),
+            transactional: Transactional::NotApplicable,
+            duration_ms: RunDuration::Duration(value.duration_ms),
+            error_reason: MigrationErrors::None,
+        }
+    }
+
+    fn preview_sql(sql: &str) -> String {
+        let res = sql.lines().take(10).collect::<Vec<_>>().join("\n") + "...";
+        res.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MigrationState {
+    Existing,
+    Unapplied,
+    FailedUnapplied,
+    NewApplied,
+}
+
+impl std::fmt::Display for MigrationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Existing => write!(f, "EXISTING"),
+            Self::Unapplied => write!(f, "UNAPPLIED"),
+            Self::FailedUnapplied => write!(f, "FAIL"),
+            Self::NewApplied => write!(f, "NEW_APPLIED"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Transactional {
+    NoTransaction,
+    InTransaction,
+    NotApplicable,
+}
+
+impl std::fmt::Display for Transactional {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoTransaction => write!(f, "NO_TRANSACTION"),
+            Self::InTransaction => write!(f, "IN_TRANSACTION"),
+            Self::NotApplicable => write!(f, "N/A"),
+        }
+    }
+}
+
+impl Transactional {
+    fn from_boolean(v: bool) -> Self {
+        if v {
+            return Self::NoTransaction;
+        };
+        Self::InTransaction
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RunDuration {
+    Duration(i64),
+    Unapplied,
+}
+
+impl std::fmt::Display for RunDuration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Duration(ms) => write!(f, "{}ms", ms),
+            Self::Unapplied => write!(f, "UNAPPLIED"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum MigrationErrors {
+    Reason(String),
+    None,
+}
+
+impl std::fmt::Display for MigrationErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Reason(e) => write!(f, "{}", e),
+            Self::None => write!(f, "SUCCESS"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod prelude {
     pub use derrick_core::prelude::*;
+    pub use derrick_migrate::Runner;
 }
 
 pub mod reexport {
@@ -16,10 +17,8 @@ pub mod types {
 }
 
 pub use derrick_core::error::Error;
-pub use derrick_migrate::Runner;
+pub use derrick_migrate::{sqlx_postgres, DisplayMigration, MigrationReport};
 
 pub use derrick_migrate_cli as cli;
-
-pub use derrick_migrate::sqlx_postgres;
 
 pub use derrick_macros::{self as macros, forward_migrate_to_field, QueryBuilder, Runtime};


### PR DESCRIPTION
A migration with more than one query cannot be executed with the `sqlx::query_*` family because they're sent as prepared statements.  Change to use `sqlx::raw_query`.  Also add a "report" type with display properties (closes #3). 