### PR TITLE
drop sqlparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "sha2",
- "sqlparser",
  "sqlx",
  "thiserror",
  "url",
@@ -359,9 +358,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "sqlparser",
  "syn 2.0.85",
- "thiserror",
 ]
 
 [[package]]
@@ -1238,15 +1235,6 @@ checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom",
  "unicode_categories",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
-dependencies = [
- "log",
 ]
 
 [[package]]

--- a/derrick-core/Cargo.toml
+++ b/derrick-core/Cargo.toml
@@ -11,6 +11,5 @@ futures-core = "0.3.25"
 futures-util = "0.3.25"
 sha2 = { version = "0.10", default-features = false }
 sqlx = "0.7"
-sqlparser = "0.51"
 thiserror = "1.0"
 url = { version = "2.5", default-features = false }

--- a/derrick-core/src/error.rs
+++ b/derrick-core/src/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
     #[error("runtime could not resolve query: {0}")]
     ResolveQuery(String),
     #[error("could not parse migration query: {0}")]
-    Sql(#[from] sqlparser::parser::ParserError),
+    Sql(#[from] std::fmt::Error),
     /// A migration was found in the history table but not
     /// in the directory of migrations.
     #[error("migration {0} applied before but missing in resolved migrations")]

--- a/derrick-core/src/migrations/migration.rs
+++ b/derrick-core/src/migrations/migration.rs
@@ -2,10 +2,6 @@ use super::source::{MigrationQuery, MigrationSource};
 use crate::error::Error;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use sqlparser::{
-    dialect::GenericDialect,
-    parser::{Parser, ParserOptions},
-};
 use std::borrow::Cow;
 
 /// A migration that can be applied.
@@ -29,17 +25,7 @@ impl Migration {
     pub fn new(source: &MigrationSource, query: MigrationQuery) -> Result<Self, Error> {
         let sql = query.sql();
         let no_tx = query.no_tx();
-        let opts = ParserOptions::new()
-            .with_trailing_commas(true)
-            .with_unescape(false);
-        let dialect = GenericDialect {};
-        let statements = Parser::new(&dialect)
-            .with_options(opts)
-            .try_with_sql(sql)?
-            .parse_statements()?
-            .into_iter()
-            .map(|statement| statement.to_string())
-            .collect::<Vec<_>>();
+        let statements = query.statements()?;
 
         Ok(Self {
             version: source.version,

--- a/derrick-derive/Cargo.toml
+++ b/derrick-derive/Cargo.toml
@@ -10,7 +10,5 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 regex = "1.10"
-sqlparser = "0.51"
 syn = "2.0"
 proc-macro2 = "1.0"
-thiserror = "1.0"

--- a/derrick-derive/src/runtime.rs
+++ b/derrick-derive/src/runtime.rs
@@ -37,7 +37,7 @@ pub fn expand(input: syn::DeriveInput) -> Result<TokenStream> {
                 let statements = src.statements().map_err(|e| {
                     Error::new(
                         token.module_orig.span(),
-                        format!("could not read raw sql: {}", e),
+                        format!("could not read raw sql: {e:?}"),
                     )
                 })?;
                 let quote_mod = token.quote_sql_migration_mod(statements);

--- a/derrick-migrate/src/report.rs
+++ b/derrick-migrate/src/report.rs
@@ -13,6 +13,10 @@ impl MigrationReport {
     pub fn new(report: Vec<DisplayMigration>) -> Self {
         Self { report }
     }
+
+    pub fn get(&self) -> &[DisplayMigration] {
+        &self.report
+    }
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
For #11 -- The `sqlparser` crate doesn't work on a lot of queries, and is unnecessary anyway.